### PR TITLE
Set new share prev hash and uncles

### DIFF
--- a/src/shares/chain/chain.rs
+++ b/src/shares/chain/chain.rs
@@ -75,7 +75,6 @@ impl Chain {
         }
         // add the new share as a tip
         self.tips.insert(blockhash);
-
         // handle potential reorgs
         // get total difficulty up to prev_share_blockhash
         if let Some(prev_share_blockhash) = prev_share_blockhash {
@@ -160,6 +159,15 @@ impl Chain {
     /// Get the total difficulty of the chain
     pub fn get_total_difficulty(&self) -> Decimal {
         self.total_difficulty
+    }
+
+    /// Get the chain tip and uncles
+    pub fn get_chain_tip_and_uncles(&self) -> (Option<BlockHash>, HashSet<BlockHash>) {
+        let mut uncles = self.tips.clone();
+        if let Some(tip) = self.chain_tip {
+            uncles.remove(&tip);
+        }
+        (self.chain_tip, uncles)
     }
 }
 

--- a/src/shares/receive_mining_message.rs
+++ b/src/shares/receive_mining_message.rs
@@ -44,10 +44,6 @@ pub fn start_receiving_mining_messages(
     let miner_pubkey = config.miner.pubkey.clone();
     tokio::spawn(async move {
         while let Some(mining_message_data) = mining_message_rx.recv().await {
-            info!(
-                "Received mining message serialized: {:?}",
-                mining_message_data
-            );
             let mining_message: CkPoolMessage =
                 serde_json::from_value(mining_message_data).unwrap();
             info!("Received mining message deserialized: {:?}", mining_message);

--- a/tests/receive_shares_working_from_ckpool_test.rs
+++ b/tests/receive_shares_working_from_ckpool_test.rs
@@ -141,7 +141,6 @@ mod zmq_tests {
         // Publish each message from test data
         for message in ckpool_messages {
             let serialized = serde_json::to_string(&message).unwrap();
-            tracing::debug!("Publishing message: {:?}", &message);
             publisher
                 .send(&serialized, 0)
                 .expect("Failed to publish message");
@@ -176,7 +175,22 @@ mod zmq_tests {
                     .unwrap()
             )
         );
-
+        let share_at_tip = chain_handle
+            .get_share(
+                "00000000debd331503c0e5348801a2057d2b8c8b96dcfb075d5a283954846173"
+                    .parse()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            share_at_tip.prev_share_blockhash,
+            Some(
+                "00000000debd331503c0e5348801a2057d2b8c8b96dcfb075d5a283954846172"
+                    .parse()
+                    .unwrap()
+            )
+        );
         let workbase = chain_handle.get_workbase(7460801854683742211).await;
         assert!(workbase.is_none());
 


### PR DESCRIPTION
We do this when we receive new shares from ckpool. We do not change prehash or uncles of shares from our peers