### PR TITLE
Validate share meets current bitcoin diff

### DIFF
--- a/src/shares/validation/bitcoin_block_validation.rs
+++ b/src/shares/validation/bitcoin_block_validation.rs
@@ -16,22 +16,39 @@
 
 use crate::bitcoind_rpc::BitcoindRpcClient;
 use crate::config::BitcoinConfig;
+use crate::shares::ShareBlock;
 use bitcoin::consensus::encode::serialize;
+use rust_decimal::Decimal;
 use serde_json::json;
 use std::error::Error;
 
+/// Get current bitcoin difficulty from rpc
+/// Compare that to the share difficulty.
+/// If the share difficulty is higher than or equal to current bitcoin difficulty, then validate bitcoin block using rpc
+/// Finally return true is the block is accepted as valid by getblocktemplate proposal mode.
+/// Raises an error if any of the rpc call fails
+pub async fn meets_bitcoin_difficulty(
+    share: &ShareBlock,
+    block: &bitcoin::Block,
+    config: &BitcoinConfig,
+) -> Result<bool, Box<dyn Error>> {
+    let bitcoind = BitcoindRpcClient::new(&config.url, &config.username, &config.password)?;
+    let difficulty = bitcoind.get_difficulty().await?;
+    let share_difficulty = share.miner_share.sdiff;
+    if share_difficulty >= Decimal::from_f64_retain(difficulty).unwrap() {
+        Ok(validate_bitcoin_block(block, config).await?)
+    } else {
+        Ok(false)
+    }
+}
+
 /// Validate the bitcoin block
-/// We expect the block to exist in the chain, if it does not, we return an error and the client should retry
-///
-/// # Arguments
-///
-/// * `block` - The bitcoin block to validate
-/// * `config` - The config with the BitcoinConfig struct
+/// Expect the block to exist in the chain, if it does not, return an error and the client should retry
 #[allow(dead_code)]
 pub async fn validate_bitcoin_block(
     block: &bitcoin::Block,
     config: &BitcoinConfig,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<bool, Box<dyn Error>> {
     // Serialize block to hex string for RPC call
     let block_hex = hex::encode(serialize(block));
 
@@ -50,11 +67,10 @@ pub async fn validate_bitcoin_block(
     }
 
     if let Ok(response) = result {
-        if response == "duplicate" {
-            return Ok(());
-        }
+        Ok(response == "duplicate")
+    } else {
+        Err(format!("Bitcoin block validation failed").into())
     }
-    Err(format!("Bitcoin block validation failed").into())
 }
 
 #[cfg(test)]
@@ -114,6 +130,7 @@ mod tests {
         // Test validation
         let result = validate_bitcoin_block(&block, &config).await;
         assert!(result.is_ok());
+        assert!(result.unwrap());
     }
 
     #[test_log::test(tokio::test)]
@@ -161,7 +178,8 @@ mod tests {
 
         // Test validation
         let result = validate_bitcoin_block(&block, &config).await;
-        assert!(result.is_err());
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
     }
 
     #[test_log::test(tokio::test)]
@@ -207,5 +225,145 @@ mod tests {
         // Test validation
         let result = validate_bitcoin_block(&block, &config).await;
         assert!(result.is_err());
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_meets_bitcoin_difficulty_matching() {
+        // Start mock server
+        let mock_server = MockServer::start().await;
+        let block_hex_string = include_str!("../../../tests/test_data/seralized/block_1.txt");
+        let block_hex = hex::decode(block_hex_string).unwrap();
+        let block = bitcoin::Block::consensus_decode(&mut block_hex.as_slice()).unwrap();
+
+        // Set up mock auth
+        let auth_header = format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD
+                .encode(format!("{}:{}", "testuser", "testpass"))
+        );
+
+        // Mock getdifficulty call
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", &auth_header))
+            .and(body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "getdifficulty",
+                "params": [],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "result": 1.0,
+                "id": 0
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Mock getblocktemplate call
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", &auth_header))
+            .and(body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "getblocktemplate",
+                "params": [{
+                    "mode": "proposal",
+                    "data": block_hex_string
+                }],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "result": "duplicate",
+                "id": 0
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Create test config
+        let config = BitcoinConfig {
+            network: bitcoin::Network::Regtest,
+            url: mock_server.uri(),
+            username: "testuser".to_string(),
+            password: "testpass".to_string(),
+        };
+
+        // Create share with matching difficulty
+        let mut share = crate::test_utils::test_share_block(
+            Some("0000000086704a35f17580d06f76d4c02d2b1f68774800675fb45f0411205bb5"),
+            None,
+            vec![],
+            None,
+            None,
+            None,
+            None,
+            Some(rust_decimal::Decimal::from_f64_retain(1.0).unwrap()),
+            &mut vec![],
+        );
+
+        // Test validation
+        let result = meets_bitcoin_difficulty(&share, &block, &config).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_validate_bitcoin_block_share_difficulty_too_low() {
+        // Start mock server
+        let mock_server = MockServer::start().await;
+        let block_hex_string = include_str!("../../../tests/test_data/seralized/block_1.txt");
+        let block_hex = hex::decode(block_hex_string).unwrap();
+        let block = bitcoin::Block::consensus_decode(&mut block_hex.as_slice()).unwrap();
+
+        // Set up mock auth
+        let auth_header = format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD.encode(format!("testuser:testpass"))
+        );
+
+        // Mock difficulty call to return higher difficulty than share
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("Authorization", &auth_header))
+            .and(body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "getdifficulty",
+                "params": [],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "result": 2.0, // Network difficulty is 2.0
+                "id": 0
+            })))
+            .mount(&mock_server)
+            .await;
+
+        // Create test config
+        let config = BitcoinConfig {
+            network: bitcoin::Network::Regtest,
+            url: mock_server.uri(),
+            username: "testuser".to_string(),
+            password: "testpass".to_string(),
+        };
+
+        // Create share with difficulty lower than network
+        let mut share = crate::test_utils::test_share_block(
+            Some("0000000086704a35f17580d06f76d4c02d2b1f68774800675fb45f0411205bb5"),
+            None,
+            vec![],
+            None,
+            None,
+            None,
+            None,
+            Some(rust_decimal::Decimal::from_f64_retain(1.0).unwrap()), // Share difficulty is 1.0
+            &mut vec![],
+        );
+
+        // Test validation - should return Ok(false) since share difficulty is too low
+        let result = meets_bitcoin_difficulty(&share, &block, &config).await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
     }
 }


### PR DESCRIPTION
We will need this function to validate received shares as meeting bitcoin diff and marking it.

There is an open question, what happens when a share is received during difficulty adjustment. What if it met older diff, but does not meet the new diff. We will look into this when we come to using shares marked as meeting difficulty. We probably will need to check how many confirmations the block has.