### PR TITLE
feat: propagate errors up the call stack

### DIFF
--- a/src/node/p2p_message_handlers/mod.rs
+++ b/src/node/p2p_message_handlers/mod.rs
@@ -64,12 +64,8 @@ pub async fn handle_request<C: 'static>(
             handle_share_headers(share_headers, chain_handle, time_provider).await
         }
         Message::ShareBlock(share_block) => {
-            if let Err(e) = handle_share_block::<void::Void>(
-                share_block,
-                chain_handle,
-                time_provider,
-            )
-            .await
+            if let Err(e) =
+                handle_share_block::<void::Void>(share_block, chain_handle, time_provider).await
             {
                 error!("Failed to add share: {}", e);
                 return Err(format!("Failed to add share: {}", e).into());


### PR DESCRIPTION
When recieving invalid shares or workspaces instead of previously just logging the error it now propagates to the `handle_gossip_message` function 

Have updated the test to verify error  propagation
