### PR TITLE
fix: incorrect use of void::Void type in handle_share_block

### DIFF
--- a/src/node/gossip_handler.rs
+++ b/src/node/gossip_handler.rs
@@ -83,7 +83,7 @@ async fn handle_gossip_message(
             info!("Handling mining share: {:?}", mining_share);
             let time_provider = SystemTimeProvider {};
             if let Err(e) =
-                handle_share_block::<void::Void>(mining_share, chain_handle, &time_provider).await
+                handle_share_block::<()>(mining_share, chain_handle, &time_provider).await
             {
                 error!("Failed to add share: {}", e);
                 return Err(format!("Failed to add share, Error: {}", e).into());


### PR DESCRIPTION
I noticed a potential issue in the following line:

```rust
handle_share_block::<void::Void>(mining_share, chain_handle, &time_provider).await
```

The type `void::Void` seems incorrect, as Rust typically uses `()` for empty types or when no value is returned. I've corrected this by replacing `void::Void` with `()`:

```rust
handle_share_block::<()>(mining_share, chain_handle, &time_provider).await
```

This should resolve the issue and align with Rust's conventions.