### PR TITLE
remove outdated TODO about nonce and ntime from MinerShare

### DIFF
--- a/src/shares/miner_message/builders.rs
+++ b/src/shares/miner_message/builders.rs
@@ -73,7 +73,6 @@ pub fn compute_merkle_root_from_txids(txids: &Vec<bitcoin::Txid>) -> Option<bitc
 }
 
 /// Builds a bitcoin block header from a workbase and a share
-/// TOOD: Update nonce and ntime from MinerShare
 pub fn build_bitcoin_header(
     workbase: &MinerWorkbase,
     share: &MinerShare,


### PR DESCRIPTION
This PR removes an outdated TODO comment:

/// TOOD: Update nonce and ntime from MinerShare

The nonce and ntime are already correctly populated from MinerShare:

    ntime is set using share.ntime.to_consensus_u32()

    nonce is parsed from share.nonce as a hex string

The comment is outdated and slightly misspelled (TOOD → TODO), so it's been removed for clarity.