### PR TITLE
implementing tokio tower service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,7 +2204,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
 ]
@@ -3217,6 +3217,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower 0.5.2",
  "tracing",
  "tracing-subscriber",
  "void",
@@ -4727,6 +4728,16 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/p2poolv2_lib/Cargo.toml
+++ b/p2poolv2_lib/Cargo.toml
@@ -25,6 +25,7 @@ zmq = { workspace = true }
 bitcoin = { workspace = true }
 base64 = { workspace = true }
 void = { workspace = true }
+tower = "0.5.2"
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
 bitcoindrpc = { path = '../bitcoindrpc' }

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -160,8 +160,8 @@ impl NodeActor {
 
     async fn run(mut self) {
         // Initialize P2PService and TimeProvider
-        let p2p_service = P2PService;
-        let time_provider = SystemTimeProvider;
+        let p2p_service = P2PService {};
+        let time_provider = SystemTimeProvider {};
         loop {
             tokio::select! {
                 buf = self.node.swarm_rx.recv() => {

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -17,7 +17,11 @@
 use crate::command::Command;
 use crate::config::Config;
 use crate::node::Node;
+use crate::node::P2PoolBehaviourEvent;
+use crate::node::RequestResponseEvent;
+use crate::node::SwarmEvent;
 use crate::node::SwarmSend;
+use crate::service::p2p_service::{P2PService, RequestContext};
 #[cfg(test)]
 #[mockall_double::double]
 use crate::shares::chain::actor::ChainHandle;
@@ -25,9 +29,12 @@ use crate::shares::chain::actor::ChainHandle;
 use crate::shares::chain::actor::ChainHandle;
 use crate::shares::miner_message::MinerWorkbase;
 use crate::shares::ShareBlock;
+use crate::utils::time_provider::SystemTimeProvider;
+use crate::utils::time_provider::TimeProvider;
 use libp2p::futures::StreamExt;
 use std::error::Error;
 use tokio::sync::{mpsc, oneshot};
+use tower::Service;
 use tracing::{debug, error, info};
 
 /// NodeHandle provides an interface to interact with a Node running in a separate task
@@ -152,6 +159,9 @@ impl NodeActor {
     }
 
     async fn run(mut self) {
+        // Initialize P2PService and TimeProvider
+        let p2p_service = P2PService;
+        let time_provider = SystemTimeProvider;
         loop {
             tokio::select! {
                 buf = self.node.swarm_rx.recv() => {
@@ -176,9 +186,31 @@ impl NodeActor {
                     }
                 },
                 event = self.node.swarm.select_next_some() => {
+                    match event {
+                        SwarmEvent::Behaviour(P2PoolBehaviourEvent::RequestResponse(
+                            RequestResponseEvent::Message { peer, message: libp2p::request_response::Message::Request{request, channel, ..} }
+                        )) => {
+                            let ctx= RequestContext {
+                                peer,
+                                request,
+                                chain_handle: self.node.chain_handle.clone(),
+                                response_channel: channel,
+                                swarm_tx: self.node.swarm_tx.clone(),
+                                time_provider: time_provider.clone(),
+                            };
+                            let mut service = p2p_service.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = service.call(ctx).await {
+                                    error!("Failed to handle request: {}", e);
+                                }
+                            });
+                    }
+                    _=> {
                     if let Err(e) = self.node.handle_swarm_event(event).await {
                         error!("Error handling swarm event: {}", e);
                     }
+                }
+            }
                 },
                 command = self.command_rx.recv() => {
                     match command {

--- a/p2poolv2_lib/src/node/actor.rs
+++ b/p2poolv2_lib/src/node/actor.rs
@@ -17,11 +17,7 @@
 use crate::command::Command;
 use crate::config::Config;
 use crate::node::Node;
-use crate::node::P2PoolBehaviourEvent;
-use crate::node::RequestResponseEvent;
-use crate::node::SwarmEvent;
 use crate::node::SwarmSend;
-use crate::service::p2p_service::{P2PService, RequestContext};
 #[cfg(test)]
 #[mockall_double::double]
 use crate::shares::chain::actor::ChainHandle;
@@ -29,12 +25,9 @@ use crate::shares::chain::actor::ChainHandle;
 use crate::shares::chain::actor::ChainHandle;
 use crate::shares::miner_message::MinerWorkbase;
 use crate::shares::ShareBlock;
-use crate::utils::time_provider::SystemTimeProvider;
-use crate::utils::time_provider::TimeProvider;
 use libp2p::futures::StreamExt;
 use std::error::Error;
 use tokio::sync::{mpsc, oneshot};
-use tower::Service;
 use tracing::{debug, error, info};
 
 /// NodeHandle provides an interface to interact with a Node running in a separate task
@@ -159,9 +152,6 @@ impl NodeActor {
     }
 
     async fn run(mut self) {
-        // Initialize P2PService and TimeProvider
-        let p2p_service = P2PService {};
-        let time_provider = SystemTimeProvider {};
         loop {
             tokio::select! {
                 buf = self.node.swarm_rx.recv() => {
@@ -186,31 +176,9 @@ impl NodeActor {
                     }
                 },
                 event = self.node.swarm.select_next_some() => {
-                    match event {
-                        SwarmEvent::Behaviour(P2PoolBehaviourEvent::RequestResponse(
-                            RequestResponseEvent::Message { peer, message: libp2p::request_response::Message::Request{request, channel, ..} }
-                        )) => {
-                            let ctx= RequestContext {
-                                peer,
-                                request,
-                                chain_handle: self.node.chain_handle.clone(),
-                                response_channel: channel,
-                                swarm_tx: self.node.swarm_tx.clone(),
-                                time_provider: time_provider.clone(),
-                            };
-                            let mut service = p2p_service.clone();
-                            tokio::spawn(async move {
-                                if let Err(e) = service.call(ctx).await {
-                                    error!("Failed to handle request: {}", e);
-                                }
-                            });
-                    }
-                    _=> {
                     if let Err(e) = self.node.handle_swarm_event(event).await {
                         error!("Error handling swarm event: {}", e);
                     }
-                }
-            }
                 },
                 command = self.command_rx.recv() => {
                     match command {

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -233,7 +233,7 @@ impl Node {
                                 peer_id, e
                             );
                         } else {
-                            info!("Outbound connection established to peer: {}", peer_id);
+                            info!("Outbound connection established to peer: {}", peer_id,);
                         }
                     }
                     libp2p::core::ConnectedPoint::Listener { .. } => {
@@ -252,7 +252,20 @@ impl Node {
                 error,
                 connection_id,
             } => {
-                error!("Failed to connect to peer: {peer_id:?}, error: {error}, connection_id: {connection_id}");
+                // Check if we're already connected to this peer
+                if peer_id.is_some() && self.swarm.is_connected(&peer_id.unwrap()) {
+                    // This is likely just a duplicate connection attempt to a peer we're already connected to
+                    debug!(
+                        "Connection attempt to already connected peer {}: {}",
+                        peer_id.unwrap(),
+                        error
+                    );
+                } else {
+                    error!("Failed to connect to peer: {peer_id:?}, error: {error}, connection_id: {connection_id}");
+                    if let Some(source) = error.source() {
+                        error!("Error source: {}", source);
+                    }
+                }
                 Ok(())
             }
             SwarmEvent::Behaviour(event) => match event {

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/getblocks.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/getblocks.rs
@@ -33,13 +33,13 @@ const MAX_BLOCKS: usize = 500;
 /// - use the locator to find the blockhashes to respond with
 /// - limit the number of blocks to MAX_BLOCKS
 /// - generate an inventory message to send blockhashes
-pub async fn handle_getblocks<C: 'static>(
+pub async fn handle_getblocks<C: 'static + Send + Sync>(
     locator: Vec<ShareBlockHash>,
     stop_block_hash: ShareBlockHash,
     chain_handle: ChainHandle,
     response_channel: C,
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), Box<dyn Error + Send + Sync>> {
     info!("Received getblocks: {:?}", locator);
     let response_block_hashes = chain_handle
         .get_blockhashes_for_locator(locator, stop_block_hash, MAX_BLOCKS)

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/getheaders.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/getheaders.rs
@@ -32,13 +32,13 @@ const MAX_HEADERS: usize = 2000;
 /// - start from chain tip, find blockhashes up to the stop block hash
 /// - limit the number of blocks to MAX_HEADERS
 /// - respond with send all headers found
-pub async fn handle_getheaders<C: 'static>(
+pub async fn handle_getheaders<C: 'static + Send + Sync>(
     block_hashes: Vec<ShareBlockHash>,
     stop_block_hash: ShareBlockHash,
     chain_handle: ChainHandle,
     response_channel: C,
     swarm_tx: mpsc::Sender<SwarmSend<C>>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), Box<dyn Error + Send + Sync>> {
     info!("Received getheaders: {:?}", block_hashes);
     let response_headers = chain_handle
         .get_headers_for_locator(block_hashes, stop_block_hash, MAX_HEADERS)

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_blocks.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_blocks.rs
@@ -29,11 +29,12 @@ use tracing::{error, info};
 ///
 /// Validate the ShareBlock and store it in the chain
 /// We do not send any inventory message as we do not want to gossip the share block.
-pub async fn handle_share_block(
+/// Share blocks are gossiped using the libp2p gossipsub protocol.
+pub async fn handle_share_block<T: TimeProvider + Send + Sync>(
     share_block: ShareBlock,
     chain_handle: ChainHandle,
-    time_provider: &impl TimeProvider,
-) -> Result<(), Box<dyn Error>> {
+    time_provider: &T,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
     info!("Received share block: {:?}", share_block);
     if let Err(e) = validation::validate(&share_block, &chain_handle, time_provider).await {
         error!("Share block validation failed: {}", e);

--- a/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
+++ b/p2poolv2_lib/src/node/p2p_message_handlers/receivers/share_headers.rs
@@ -30,11 +30,11 @@ use tracing::info;
 /// 2. TODO: Store the headers
 /// 2. TODO: Push the header into a task queue to fetch txs to build the ShareBlock
 /// 3. TODO: We need to start a task in node to pull from the task queue and send getData message for txs
-pub async fn handle_share_headers(
+pub async fn handle_share_headers<T: TimeProvider + Send + Sync>(
     share_headers: Vec<ShareHeader>,
     _chain_handle: ChainHandle,
-    _time_provider: &impl TimeProvider,
-) -> Result<(), Box<dyn Error>> {
+    _time_provider: &T,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
     info!("Received share headers: {:?}", share_headers);
     Ok(())
 }

--- a/p2poolv2_lib/src/service/mod.rs
+++ b/p2poolv2_lib/src/service/mod.rs
@@ -14,13 +14,4 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod cli_commands;
-pub mod command;
-pub mod config;
-pub mod node;
-pub mod service;
-pub mod shares;
-pub mod utils;
-
-#[cfg(test)]
-pub mod test_utils;
+pub mod p2p_service;

--- a/p2poolv2_lib/src/service/p2p_service.rs
+++ b/p2poolv2_lib/src/service/p2p_service.rs
@@ -1,0 +1,66 @@
+// Copyright (C) 2024, 2025 P2Poolv2 Developers (see AUTHORS)
+//
+//  This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use std::error::Error;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::Future;
+use tokio::sync::mpsc;
+use tower::Service;
+
+use crate::node::messages::Message;
+use crate::node::p2p_message_handlers::handle_request;
+use crate::node::SwarmSend;
+#[cfg_attr(test, mockall_double::double)]
+use crate::shares::chain::actor::ChainHandle;
+use crate::utils::time_provider::TimeProvider;
+
+/// Request context wrapping all inputs for the service call.
+pub struct RequestContext<C, T> {
+    pub peer: libp2p::PeerId,
+    pub request: Message,
+    pub chain_handle: ChainHandle,
+    pub response_channel: C,
+    pub swarm_tx: mpsc::Sender<SwarmSend<C>>,
+    pub time_provider: T,
+}
+
+/// The Tower service that processes inbound P2P requests.
+#[derive(Clone)]
+pub struct P2PService;
+
+impl<C: 'static + Send + Sync, T: TimeProvider + Send + Sync + 'static>
+    Service<RequestContext<C, T>> for P2PService
+{
+    type Response = ();
+    type Error = Box<dyn Error + Send + Sync>;
+    type Future = Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Always ready
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: RequestContext<C, T>) -> Self::Future {
+        Box::pin(async move {
+            handle_request(req).await.map_err(|e| {
+                tracing::error!("Service failed to process request: {}", e);
+                e
+            })
+        })
+    }
+}

--- a/p2poolv2_lib/src/shares/validation/mod.rs
+++ b/p2poolv2_lib/src/shares/validation/mod.rs
@@ -41,7 +41,7 @@ pub async fn validate(
     share: &ShareBlock,
     chain_handle: &ChainHandle,
     time_provider: &impl TimeProvider,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), Box<dyn Error + Send + Sync>> {
     if let Err(e) = validate_timestamp(share, time_provider).await {
         return Err(format!("Share timestamp validation failed: {}", e).into());
     }

--- a/tests/receive_shares_from_self_and_peers_test.rs
+++ b/tests/receive_shares_from_self_and_peers_test.rs
@@ -20,6 +20,7 @@ use common::{default_test_config, simple_miner_workbase};
 use p2poolv2_lib::node::actor::NodeHandle;
 use p2poolv2_lib::node::messages::Message;
 use p2poolv2_lib::node::p2p_message_handlers::handle_request;
+use p2poolv2_lib::service::p2p_service::RequestContext;
 use p2poolv2_lib::shares::chain::actor::ChainHandle;
 use p2poolv2_lib::shares::miner_message::CkPoolMessage;
 use p2poolv2_lib::shares::ShareBlock;
@@ -121,15 +122,15 @@ async fn receive_shares_and_workbases_from_self_and_peers() {
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let response = handle_request(
-            peer_id,
-            peer_msg.clone(),
-            chain_handle.clone(),
-            response_channel_tx.clone(),
-            swarm_tx.clone(),
-            &time_provider,
-        )
-        .await;
+        let ctx = RequestContext {
+            peer: peer_id,
+            request: peer_msg.clone(),
+            chain_handle: chain_handle.clone(),
+            response_channel: response_channel_tx.clone(),
+            swarm_tx: swarm_tx.clone(),
+            time_provider,
+        };
+        let response = handle_request(ctx).await;
         let _ww = chain_handle.get_workbase(7473434392883363844).await;
         tracing::debug!("Peer message response: {:?}", &response);
         assert!(response.is_ok(), "Peer message handling failed");
@@ -138,7 +139,11 @@ async fn receive_shares_and_workbases_from_self_and_peers() {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let peer_shares = chain_handle.get_shares_at_height(0).await;
-    let peer_share = peer_shares.values().next().unwrap();
+    tracing::debug!("Peer shares: {:?}", &peer_shares);
+    let peer_share = peer_shares
+        .values()
+        .next()
+        .expect("No peer shares found at height 0");
 
     // For this test, we forced prev_share_blockhash to be None
     assert!(
@@ -200,24 +205,24 @@ async fn test_rate_limiting() {
     let time_provider = SystemTimeProvider {};
 
     // sending two workbase messages quickly, the second one should be rate-limited.
-    let result1 = handle_request(
-        peer_id,
-        Message::Workbase(workbase.clone()),
-        chain_handle.clone(),
-        (),
-        swarm_tx.clone(),
-        &time_provider,
-    )
+    let result1 = handle_request(RequestContext {
+        peer: peer_id,
+        request: Message::Workbase(workbase.clone()),
+        chain_handle: chain_handle.clone(),
+        response_channel: (),
+        swarm_tx: swarm_tx.clone(),
+        time_provider: time_provider.clone(),
+    })
     .await;
 
-    let result2 = handle_request(
-        peer_id,
-        Message::Workbase(workbase.clone()),
-        chain_handle.clone(),
-        (),
-        swarm_tx.clone(),
-        &time_provider,
-    )
+    let result2 = handle_request(RequestContext {
+        peer: peer_id,
+        request: Message::Workbase(workbase.clone()),
+        chain_handle: chain_handle.clone(),
+        response_channel: (),
+        swarm_tx: swarm_tx.clone(),
+        time_provider: time_provider.clone(),
+    })
     .await;
 
     assert!(result1.is_ok(), "First request should succeed");
@@ -225,14 +230,14 @@ async fn test_rate_limiting() {
 
     // wait longer than the rate limit window, then send again to succed
     tokio::time::sleep(Duration::from_secs(2)).await;
-    let result3 = handle_request(
-        peer_id,
-        Message::Workbase(workbase.clone()),
-        chain_handle.clone(),
-        (),
-        swarm_tx.clone(),
-        &time_provider,
-    )
+    let result3 = handle_request(RequestContext {
+        peer: peer_id,
+        request: Message::Workbase(workbase.clone()),
+        chain_handle: chain_handle.clone(),
+        response_channel: (),
+        swarm_tx: swarm_tx.clone(),
+        time_provider: time_provider.clone(),
+    })
     .await;
     assert!(
         result3.is_ok(),


### PR DESCRIPTION
To implement scalable and maintainable DoS protection mechanisms, we need to refactor our networking stack by integrating the Tokio Tower framework. Our current REQ/REP protocol is monolithic and does not support modular middleware, which limits extensibility and robustness.

This PR focuses on implementing a Tower service to enable modular middleware support, improve request handling, and enhance the overall scalability and maintainability of our networking layer.