### PR TITLE
Listen to zmq new block events and notify miners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4357,6 +4357,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wiremock",
+ "zmq",
 ]
 
 [[package]]

--- a/config.1.toml
+++ b/config.1.toml
@@ -26,7 +26,7 @@ port = 13333
 start_difficulty = 1
 minimum_difficulty = 1
 solo_address = "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk"
-
+zmqpubhashblock = "tcp://127.0.0.1:28332"
 
 [miner]
 pubkey = "020202020202020202020202020202020202020202020202020202020202020202"

--- a/config.2.toml
+++ b/config.2.toml
@@ -26,7 +26,7 @@ port = 23333
 start_difficulty = 1
 minimum_difficulty = 1
 solo_address = "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk"
-
+zmqpubhashblock = "tcp://127.0.0.1:28332"
 
 [miner]
 pubkey = "020202020202020202020202020202020202020202020202020202020202020202"

--- a/config.toml
+++ b/config.toml
@@ -26,6 +26,7 @@ port = 3333
 start_difficulty = 1
 minimum_difficulty = 1
 solo_address = "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk"
+zmqpubhashblock = "tcp://127.0.0.1:28332"
 
 [miner]
 pubkey = "020202020202020202020202020202020202020202020202020202020202020202"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,12 +8,13 @@ services:
     ports:
       - "${BTC_P2P_PORT:-38333}:${BTC_P2P_PORT:-38333}" # P2P port
       - "${BTC_RPC_PORT:-38332}:${BTC_RPC_PORT:-38332}" # RPC port
+      - "28332:28332" # ZMQ port is always the same
     environment:
       - NETWORK=${NETWORK:-signet}
     command: bitcoind -conf=/etc/bitcoin/bitcoin-${NETWORK:-signet}.conf -datadir=/data-${NETWORK:-signet}
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "nc", "-z", "0.0.0.0", "${BTC_P2P_PORT:-38333}" ]
+      test: ["CMD", "nc", "-z", "0.0.0.0", "${BTC_P2P_PORT:-38333}"]
       interval: 5s
       timeout: 3s
       retries: 3
@@ -55,7 +56,7 @@ services:
     restart: unless-stopped
     command: /ckpool/src/ckpool --btcsolo --config=/ckpool-solo-${NETWORK:-signet}.json --log-shares --loglevel=7
     healthcheck:
-      test: [ "CMD", "nc", "-z", "localhost", "3333" ]
+      test: ["CMD", "nc", "-z", "localhost", "3333"]
       interval: 5s
       timeout: 3s
       retries: 3
@@ -96,7 +97,6 @@ services:
 volumes:
   bitcoin_data:
   p2pool_data:
-
 
 networks:
   p2pool_network:

--- a/docker/run-p2pool.sh
+++ b/docker/run-p2pool.sh
@@ -23,9 +23,11 @@ NETWORK=${1:-signet}
 if [ "$NETWORK" = "signet" ]; then
   BTC_P2P_PORT=38333
   BTC_RPC_PORT=38332
+  BTC_ZMQ_PORT=28332
 elif [ "$NETWORK" = "testnet4" ]; then
   BTC_P2P_PORT=48333
   BTC_RPC_PORT=48332
+  BTC_ZMQ_PORT=28332 # Note: ZMQ port is the same for both networks
 else
   echo "Unsupported network: $NETWORK. Use 'signet' or 'testnet4'."
   exit 1
@@ -35,6 +37,7 @@ fi
 export NETWORK=$NETWORK
 export BTC_P2P_PORT=$BTC_P2P_PORT
 export BTC_RPC_PORT=$BTC_RPC_PORT
+export BTC_ZMQ_PORT=$BTC_ZMQ_PORT
 
 # Remove the first argument (network) to pass remaining args to docker-compose
 shift

--- a/docker/signet/bitcoin-signet.conf
+++ b/docker/signet/bitcoin-signet.conf
@@ -446,7 +446,7 @@ listenonion=0
 
 
 # Enable publish hash block in <address>
-zmqpubhashblock=tcp://127.0.0.1:28332
+zmqpubhashblock=tcp://*:28332
 
 # Set publish hash block outbound message high water mark (default: 1000)
 #zmqpubhashblockhwm=<n>

--- a/docker/testnet4/bitcoin-testnet4.conf
+++ b/docker/testnet4/bitcoin-testnet4.conf
@@ -446,7 +446,7 @@ listenonion=0
 
 
 # Enable publish hash block in <address>
-zmqpubhashblock=tcp://127.0.0.1:28332
+zmqpubhashblock=tcp://*:28332
 
 # Set publish hash block outbound message high water mark (default: 1000)
 #zmqpubhashblockhwm=<n>

--- a/p2poolv2_bin/src/main.rs
+++ b/p2poolv2_bin/src/main.rs
@@ -86,6 +86,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             SOCKET_PATH,
             GBT_POLL_INTERVAL,
             bitcoin_config.network,
+            &stratum_config.zmqpubhashblock,
         )
         .await
         {

--- a/p2poolv2_lib/src/config.rs
+++ b/p2poolv2_lib/src/config.rs
@@ -53,6 +53,7 @@ pub struct StratumConfig {
     pub start_difficulty: u32,
     pub minimum_difficulty: u32,
     pub solo_address: Option<String>,
+    pub zmqpubhashblock: String,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -184,6 +185,11 @@ impl Config {
         self
     }
 
+    pub fn with_stratum_zmqpubhashblock(mut self, zmqpubhashblock: String) -> Self {
+        self.stratum.zmqpubhashblock = zmqpubhashblock;
+        self
+    }
+
     pub fn with_start_difficulty(mut self, start_difficulty: u32) -> Self {
         self.stratum.start_difficulty = start_difficulty;
         self
@@ -244,6 +250,7 @@ mod tests {
             .with_stratum_host("stratum.example.com".to_string())
             .with_stratum_port(3333)
             .with_stratum_solo_address("bcrt1qe2qaq0e8qlp425pxytrakala7725dynwhknufr".to_string())
+            .with_stratum_zmqpubhashblock("tcp://127.0.0.1:28332".to_string())
             .with_start_difficulty(1)
             .with_minimum_difficulty(1)
             .with_miner_pubkey(
@@ -270,6 +277,10 @@ mod tests {
         assert_eq!(
             config.stratum.solo_address,
             Some("bcrt1qe2qaq0e8qlp425pxytrakala7725dynwhknufr".to_string())
+        );
+        assert_eq!(
+            config.stratum.zmqpubhashblock,
+            "tcp://127.0.0.1:28332".to_string()
         );
 
         assert_eq!(

--- a/stratum/Cargo.toml
+++ b/stratum/Cargo.toml
@@ -22,6 +22,7 @@ base64 = { workspace = true }
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
 bitcoindrpc = { path = '../bitcoindrpc', features = ["test-utils"] }
+zmq = { workspace = true }
 
 [dev-dependencies]
 test-log = { version = "0.2.17", features = ["trace"] }

--- a/stratum/src/lib.rs
+++ b/stratum/src/lib.rs
@@ -22,3 +22,4 @@ pub mod server;
 pub mod session;
 pub mod util;
 pub mod work;
+pub(crate) mod zmq_listener;

--- a/stratum/src/lib.rs
+++ b/stratum/src/lib.rs
@@ -22,4 +22,4 @@ pub mod server;
 pub mod session;
 pub mod util;
 pub mod work;
-pub(crate) mod zmq_listener;
+pub mod zmq_listener;

--- a/stratum/src/plan.md
+++ b/stratum/src/plan.md
@@ -1,9 +1,0 @@
-A Stratum server should meet the following requirements.
-
-- [x] Provides a TCP socket that listens to incoming connections on a port provided.
-- [ ] For each incoming connection we follow the stratum messages protocol.
-- [ ] Get block templates from bitcoin node.
-- [ ] For a given block template we generate work that needs to be worked on by ASICs machines.
-- [ ] We store the block template as a serialized compact block in the database.
-- [ ] We generate a coinbase for a single coinbase address in v1.
-- [ ] Move on to use coinbase for multiple users. We need this for Hydrapool and P2Pool.

--- a/stratum/src/work/gbt.rs
+++ b/stratum/src/work/gbt.rs
@@ -131,6 +131,7 @@ pub async fn start_gbt(
     socket_path: &str,
     poll_interval: u64,
     network: bitcoin::Network,
+    zmqpubhashblock: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let bitcoind: Arc<BitcoindRpcClient> = match BitcoindRpcClient::new(
         &bitcoin_config.url,
@@ -417,6 +418,8 @@ mod gbt_server_tests {
     use super::*;
     use bitcoindrpc::test_utils::{mock_method, setup_mock_bitcoin_rpc};
     use tokio::sync::mpsc;
+    use wiremock::MockServer;
+    use wiremock::{Mock, ResponseTemplate};
 
     #[tokio::test]
     async fn test_start_gbt_trigger_from_socket_event() {
@@ -438,6 +441,8 @@ mod gbt_server_tests {
         }]);
         mock_method(&mock_server, "getblocktemplate", params, template).await;
 
+        let mock_zmq_server = MockServer::start().await;
+
         // Setup channel for receiving templates
         let (template_tx, mut template_rx) = mpsc::channel(10);
 
@@ -448,6 +453,7 @@ mod gbt_server_tests {
             socket_path,
             60,
             bitcoin::Network::Signet,
+            &mock_zmq_server.uri(),
         )
         .await;
 
@@ -490,6 +496,8 @@ mod gbt_server_tests {
         }]);
         mock_method(&mock_server, "getblocktemplate", params, template).await;
 
+        let mock_zmq_server = MockServer::start().await;
+
         // Setup channel for receiving templates
         let (template_tx, mut template_rx) = mpsc::channel(10);
 
@@ -500,6 +508,7 @@ mod gbt_server_tests {
             socket_path,
             1,
             bitcoin::Network::Signet,
+            &mock_zmq_server.uri(),
         )
         .await;
 

--- a/stratum/src/zmq_listener.rs
+++ b/stratum/src/zmq_listener.rs
@@ -16,7 +16,9 @@
 
 use tracing::info;
 
+#[allow(dead_code)]
 const ZMQ_PUB_BLOCKHASH: &str = "zmqpubblockhash";
+#[allow(dead_code)]
 const ZMQ_CHANNEL_SIZE: usize = 1;
 
 #[derive(Debug)]
@@ -30,14 +32,18 @@ impl std::fmt::Display for ZmqError {
 }
 impl std::error::Error for ZmqError {}
 
-pub(crate) trait ZmqListenerTrait {
+#[allow(dead_code)]
+pub trait ZmqListenerTrait {
     /// Starts the ZeroMQ subscriber socket.
     /// Asynchronously listens for messages on the specified address and topic, sending unit message to a channel.
     /// Returns the receiver end of the channel.
     fn start(&self, address: &str) -> Result<tokio::sync::mpsc::Receiver<()>, ZmqError>;
 }
 
-struct ZmqListener;
+#[allow(dead_code)]
+#[derive(Default)]
+pub struct ZmqListener;
+
 impl ZmqListenerTrait for ZmqListener {
     fn start(&self, address: &str) -> Result<tokio::sync::mpsc::Receiver<()>, ZmqError> {
         let context = zmq::Context::new();
@@ -142,7 +148,7 @@ mod tests {
         let mut received = false;
 
         rt.block_on(async {
-            let mut rx = ZmqListener {}
+            let mut rx = ZmqListener
                 .start(address)
                 .expect("Should create zmq listener");
 
@@ -162,7 +168,7 @@ mod tests {
     #[test]
     fn test_start_invalid_address() {
         let invalid_address = "invalid-address";
-        let result = ZmqListener {}.start(invalid_address);
+        let result = ZmqListener.start(invalid_address);
         assert!(result.is_err());
         let err = result.err().unwrap();
         assert!(err.message.contains("Failed to connect ZMQ socket"));

--- a/stratum/src/zmq_listener.rs
+++ b/stratum/src/zmq_listener.rs
@@ -1,0 +1,170 @@
+// Copyright (C) 2024, 2025 P2Poolv2 Developers (see AUTHORS)
+//
+// This file is part of P2Poolv2
+//
+// P2Poolv2 is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// P2Poolv2 is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
+
+use tracing::info;
+
+const ZMQ_PUB_BLOCKHASH: &str = "zmqpubblockhash";
+const ZMQ_CHANNEL_SIZE: usize = 1;
+
+#[derive(Debug)]
+pub struct ZmqError {
+    pub message: String,
+}
+impl std::fmt::Display for ZmqError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ZMQ Error: {}", self.message)
+    }
+}
+impl std::error::Error for ZmqError {}
+
+pub(crate) trait ZmqListenerTrait {
+    /// Starts the ZeroMQ subscriber socket.
+    /// Asynchronously listens for messages on the specified address and topic, sending unit message to a channel.
+    /// Returns the receiver end of the channel.
+    fn start(&self, address: &str) -> Result<tokio::sync::mpsc::Receiver<()>, ZmqError>;
+}
+
+struct ZmqListener;
+impl ZmqListenerTrait for ZmqListener {
+    fn start(&self, address: &str) -> Result<tokio::sync::mpsc::Receiver<()>, ZmqError> {
+        let context = zmq::Context::new();
+        let socket = context.socket(zmq::SUB).map_err(|e| ZmqError {
+            message: format!("Failed to create ZMQ socket: {:?}", e),
+        })?;
+        socket
+            .set_subscribe(ZMQ_PUB_BLOCKHASH.as_bytes())
+            .map_err(|e| ZmqError {
+                message: format!("Failed to set ZMQ subscription: {}", e),
+            })?;
+        socket.connect(address).map_err(|e| ZmqError {
+            message: format!("Failed to connect ZMQ socket: {}", e),
+        })?;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<()>(ZMQ_CHANNEL_SIZE);
+        tokio::spawn(async move {
+            loop {
+                match socket.recv_msg(0) {
+                    Ok(msg) => {
+                        if msg.is_empty() {
+                            continue; // Skip empty messages
+                        }
+                        tx.send(()).await.unwrap();
+                    }
+                    Err(e) => {
+                        info!("Failed to receive ZMQ message: {}", e);
+                    }
+                }
+            }
+        });
+        Ok(rx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+    use tokio::runtime::Runtime;
+
+    // Helper function to start a ZMQ publisher in a background thread
+    fn start_zmq_publisher(address: &str, topic: &str, message: &[u8]) {
+        let address = address.to_string();
+        let topic = topic.as_bytes().to_vec();
+        let message = message.to_vec();
+        thread::spawn(move || {
+            let ctx = zmq::Context::new();
+            let publisher = ctx.socket(zmq::PUB).unwrap();
+            publisher.bind(&address).unwrap();
+            // Give the subscriber time to connect
+            thread::sleep(Duration::from_millis(2000));
+            let mut msg = topic.clone();
+            msg.extend_from_slice(&message);
+            publisher.send(msg, 0).unwrap();
+        });
+    }
+
+    #[test]
+    fn test_zmq_error_display() {
+        let err = ZmqError {
+            message: "test error".to_string(),
+        };
+        assert_eq!(format!("{}", err), "ZMQ Error: test error");
+    }
+
+    #[test_log::test]
+    fn test_start_should_receive_message_when_zmq_socket_receieves_a_message() {
+        let rt = Runtime::new().unwrap();
+        let address = "tcp://127.0.0.1:28333";
+        let topic = ZMQ_PUB_BLOCKHASH;
+        let message = b"blockhashdata";
+
+        // Use a latch to ensure the publisher is ready
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+
+        let publisher_thread = thread::spawn(move || {
+            let ctx = zmq::Context::new();
+            let publisher = ctx.socket(zmq::PUB).unwrap();
+            publisher.bind(&address).unwrap();
+
+            // Signal that we're ready
+            ready_tx.send(()).unwrap();
+
+            // Give the subscriber time to connect
+            thread::sleep(Duration::from_millis(300));
+
+            // Send the message
+            let mut msg = topic.as_bytes().to_vec();
+            msg.extend_from_slice(message);
+            publisher.send(msg, 0).unwrap();
+
+            // Keep the socket alive for a bit
+            thread::sleep(Duration::from_millis(100));
+        });
+
+        // Wait for publisher to be ready
+        ready_rx.recv().unwrap();
+
+        let mut received = false;
+
+        rt.block_on(async {
+            let mut rx = ZmqListener {}
+                .start(address)
+                .expect("Should create zmq listener");
+
+            // Wait for the publisher to send the message with longer timeout
+            match tokio::time::timeout(Duration::from_secs(5), rx.recv()).await {
+                Ok(Some(_)) => {
+                    received = true;
+                }
+                Ok(None) => panic!("Channel closed without receiving message"),
+                Err(_) => panic!("Timeout waiting for ZMQ message"),
+            }
+        });
+        assert!(received, "Message should have been received");
+        rt.shutdown_background();
+    }
+
+    #[test]
+    fn test_start_invalid_address() {
+        let invalid_address = "invalid-address";
+        let result = ZmqListener {}.start(invalid_address);
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        assert!(err.message.contains("Failed to connect ZMQ socket"));
+    }
+}

--- a/stratum/src/zmq_listener.rs
+++ b/stratum/src/zmq_listener.rs
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU General Public License along with
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
-use tracing::info;
+use tracing::{debug, info};
 
 #[allow(dead_code)]
-const ZMQ_PUB_BLOCKHASH: &str = "zmqpubblockhash";
+const ZMQ_PUB_BLOCKHASH: &str = "hashblock"; // all messages
 #[allow(dead_code)]
 const ZMQ_CHANNEL_SIZE: usize = 1;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -63,6 +63,7 @@ pub fn default_test_config() -> Config {
             start_difficulty: 1,
             minimum_difficulty: 1,
             solo_address: Some("tb1q9w4x5z5v5f5g5h5j5k5l5m5n5o5p5q5r5s5t5u".to_string()),
+            zmqpubhashblock: "tcp://127.0.0.1:28332".to_string(),
         },
         miner: MinerConfig {
             pubkey: "020202020202020202020202020202020202020202020202020202020202020202"


### PR DESCRIPTION
Add support for listening to zmqpubhashblock messages from bitcoind. When a block tip is changed on bitcoin, we create a new jobs and send mining.notify to all workers.