### PR TITLE
handshake ratelimiter

### DIFF
--- a/config.1.toml
+++ b/config.1.toml
@@ -14,6 +14,7 @@ max_transaction_per_second = 100
 rate_limit_window_secs = 1
 max_requests_per_second= 1
 peer_inactivity_timeout_secs = 60
+dial_timeout_secs = 30
 
 [store]
 path = "./store.1.db"

--- a/config.2.toml
+++ b/config.2.toml
@@ -14,6 +14,7 @@ max_transaction_per_second = 100
 rate_limit_window_secs = 1
 max_requests_per_second = 1
 peer_inactivity_timeout_secs = 60
+dial_timeout_secs = 30
 
 [store]
 path = "./store.2.db"

--- a/config.toml
+++ b/config.toml
@@ -14,6 +14,7 @@ max_transaction_per_second = 100
 rate_limit_window_secs = 1
 max_requests_per_second = 1
 peer_inactivity_timeout_secs = 60
+dial_timeout_secs = 30
 
 [store]
 path = "./store.db"

--- a/p2poolv2_lib/src/config.rs
+++ b/p2poolv2_lib/src/config.rs
@@ -36,6 +36,7 @@ pub struct NetworkConfig {
     pub rate_limit_window_secs: u64,
     pub max_requests_per_second: u64,
     pub peer_inactivity_timeout_secs: u64,
+    pub dial_timeout_secs: u64,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/p2poolv2_lib/src/node/mod.rs
+++ b/p2poolv2_lib/src/node/mod.rs
@@ -35,9 +35,12 @@ use crate::shares::receive_mining_message::start_receiving_mining_messages;
 use crate::shares::ShareBlock;
 use crate::utils::time_provider::SystemTimeProvider;
 use behaviour::{P2PoolBehaviour, P2PoolBehaviourEvent};
+use libp2p::core::transport::Transport;
 use libp2p::identify;
 use libp2p::request_response::ResponseChannel;
+use libp2p::tcp::Config as TcpConfig;
 use libp2p::PeerId;
+use libp2p::SwarmBuilder;
 use libp2p::{
     kad::{Event as KademliaEvent, QueryResult},
     swarm::SwarmEvent,
@@ -107,13 +110,27 @@ impl Node {
             }
         };
 
-        let mut swarm = libp2p::SwarmBuilder::with_existing_identity(id_keys)
+        let dial_timeout_secs = config.network.dial_timeout_secs;
+
+        let tcp_config = TcpConfig::default().nodelay(true);
+        let noise_config = match libp2p::noise::Config::new(&id_keys) {
+            Ok(cfg) => cfg,
+            Err(err) => {
+                error!("Failed to create Noise config: {}", err);
+                return Err(Box::new(err));
+            }
+        };
+
+        let transport = libp2p::tcp::Transport::<libp2p::tcp::tokio::Tcp>::new(tcp_config.clone())
+            .upgrade(libp2p::core::upgrade::Version::V1)
+            .authenticate(noise_config)
+            .multiplex(libp2p::yamux::Config::default())
+            .timeout(Duration::from_secs(dial_timeout_secs))
+            .boxed();
+
+        let mut swarm = SwarmBuilder::with_existing_identity(id_keys)
             .with_tokio()
-            .with_tcp(
-                libp2p::tcp::Config::default(),
-                libp2p::noise::Config::new,
-                libp2p::yamux::Config::default,
-            )?
+            .with_other_transport(|_| transport)?
             .with_behaviour(|_| behavior)?
             .with_swarm_config(|cfg| {
                 cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))
@@ -404,5 +421,164 @@ impl Node {
             }
         }
         Ok(())
+    }
+}
+
+/// This test verifies that dialing an unreachable peer does not hang indefinitely,
+/// and that the libp2p Swarm emits a connection error within a reasonable timeout.
+///
+/// How it works:
+/// - We configure the node to dial a local address on an unused TCP port (`127.0.0.1:65535`).
+///   This port is almost certainly closed, so the TCP connection will either be refused immediately,
+///   or will time out during the transport handshake phase.
+/// - The Swarm is polled for events. We expect to receive a `SwarmEvent::OutgoingConnectionError`
+///   within a few seconds.
+/// - The test asserts that the error string contains either "timeout", "connection refused",
+///   or "failed to negotiate transport protocol" (to cover all error variants libp2p might emit
+///   for failed or timed-out dials).
+/// - If no such event is received within the timeout window (e.g., 5 or 10 seconds), the test fails.
+///
+/// Why this is important:
+/// - It ensures that the node’s dial logic and libp2p’s handshake timeout are working as intended,
+///   and that attempts to connect to unreachable peers do not block or hang the node.
+/// - This is critical for network robustness, as hanging dials can lead to resource exhaustion
+///   or degraded peer connectivity in real-world deployments.
+///
+/// Note:
+/// - The test does not require the error to be specifically a "timeout"; it accepts any connection
+///   failure, since the exact error string may vary by OS and libp2p version.
+/// - The test must not set connection limits (like `max_pending_outgoing`) to zero, or the dial
+///   will be denied before it is attempted.
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{
+        CkPoolConfig, Config, LoggingConfig, MinerConfig, NetworkConfig, StoreConfig, StratumConfig,
+    };
+    use crate::node::Node;
+    #[cfg_attr(test, mockall_double::double)]
+    use crate::shares::chain::actor::ChainHandle;
+    use bitcoindrpc::BitcoinRpcConfig;
+    use futures::StreamExt;
+    use std::time::{Duration, Instant};
+
+    #[tokio::test]
+    async fn test_node_dial_timeout_does_not_hang() {
+        use libp2p::swarm::SwarmEvent;
+
+        // Use a local address that will refuse connections immediately
+        let unreachable_peer = "/ip4/127.0.0.1/tcp/65535".to_string(); // Fast fail
+
+        let mut network_config = NetworkConfig {
+            listen_address: "/ip4/127.0.0.1/tcp/0".to_string(),
+            dial_peers: vec![],
+            max_pending_incoming: 10,
+            max_pending_outgoing: 10,
+            max_established_incoming: 10,
+            max_established_outgoing: 10,
+            max_established_per_peer: 10,
+            max_workbase_per_second: 10,
+            max_userworkbase_per_second: 10,
+            max_miningshare_per_second: 10,
+            max_inventory_per_second: 10,
+            max_transaction_per_second: 10,
+            rate_limit_window_secs: 1,
+            max_requests_per_second: 1,
+            peer_inactivity_timeout_secs: 30,
+            dial_timeout_secs: 2,
+        };
+        network_config.dial_peers = vec![unreachable_peer];
+        network_config.dial_timeout_secs = 2;
+
+        let mut config = Config {
+            network: network_config.clone(),
+            bitcoinrpc: BitcoinRpcConfig {
+                url: "http://localhost:8332".to_string(),
+                username: "testuser".to_string(),
+                password: "testpass".to_string(),
+            },
+            store: StoreConfig {
+                path: "test_chain.db".to_string(),
+            },
+            ckpool: CkPoolConfig {
+                host: "127.0.0.1".to_string(),
+                port: 8881,
+            },
+            stratum: StratumConfig {
+                hostname: "127.0.0.1".to_string(),
+                port: 3333,
+                start_difficulty: 1,
+                minimum_difficulty: 1,
+                maximum_difficulty: Some(1000),
+                solo_address: Some("tb1q9w4x5z5v5f5g5h5j5k5l5m5n5o5p5q5r5s5t5u".to_string()),
+                zmqpubhashblock: "tcp://127.0.0.1:28332".to_string(),
+                network: bitcoin::network::Network::Signet,
+            },
+            miner: MinerConfig {
+                pubkey: "020202020202020202020202020202020202020202020202020202020202020202"
+                    .parse()
+                    .unwrap(),
+            },
+            logging: LoggingConfig {
+                level: "info".to_string(),
+                console: false,
+                file: Some("./p2pool.log".to_string()),
+            },
+        };
+        config.network = network_config;
+
+        let mut chain_handle = ChainHandle::default();
+        chain_handle
+            .expect_clone()
+            .returning(|| ChainHandle::default());
+
+        let start = Instant::now();
+
+        let mut node = Node::new(&config, chain_handle).expect("Node initialization failed");
+
+        //  Initiate the dial manually!
+        let unreachable_peer_multiaddr: libp2p::Multiaddr =
+            config.network.dial_peers[0].parse().unwrap();
+        node.swarm
+            .dial(unreachable_peer_multiaddr.clone())
+            .expect("Dial failed to start");
+
+        let start = Instant::now();
+        let mut timeout = tokio::time::sleep(Duration::from_secs(5));
+        tokio::pin!(timeout);
+
+        loop {
+            tokio::select! {
+                                        event = node.swarm.next() => {
+                                            match event {
+                                                Some(SwarmEvent::OutgoingConnectionError { error, .. }) => {
+                                                    let elapsed = start.elapsed();
+                                                   let err_str = error.to_string();
+            let err_str_lower = err_str.to_lowercase();
+            assert!(
+                err_str_lower.contains("timeout") ||
+                err_str_lower.contains("connection refused") ||
+                err_str_lower.contains("failed to negotiate transport protocol"),
+                "Expected timeout or connection refused error, got: {}",
+                err_str
+            );
+
+
+                                                    assert!(
+                                                        elapsed.as_secs_f32() <= 10.0,
+                                                        "Dialing took too long: {:?}, expected ~10s",
+                                                        elapsed
+                                                    );
+                                                    break;
+                                                }
+                                                Some(_) => continue,
+                                                None => panic!("Swarm event stream ended unexpectedly"),
+                                            }
+                                        }
+                                        _ = &mut timeout => {
+                                            panic!("Test timed out after 5 seconds, dial timeout not triggered");
+                                        }
+                                    }
+        }
     }
 }

--- a/p2poolv2_lib/src/service/mod.rs
+++ b/p2poolv2_lib/src/service/mod.rs
@@ -335,6 +335,7 @@ mod tests {
             rate_limit_window_secs: 1,
             max_requests_per_second: 1,
             peer_inactivity_timeout_secs: 30,
+            dial_timeout_secs: 30,
         };
 
         let peer_id = PeerId::random();
@@ -421,6 +422,7 @@ mod tests {
             rate_limit_window_secs: 1,
             max_requests_per_second: 1,
             peer_inactivity_timeout_secs: 30,
+            dial_timeout_secs: 30,
         };
 
         let peer_id = PeerId::random();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -42,6 +42,7 @@ pub fn default_test_config() -> Config {
             rate_limit_window_secs: 1,
             max_requests_per_second: 1,
             peer_inactivity_timeout_secs: 60,
+            dial_timeout_secs: 30,
         },
         bitcoinrpc: BitcoinRpcConfig {
             url: "http://localhost:8332".to_string(),


### PR DESCRIPTION

Implement handshake timeout in libp2p transport and add dial timeout test

Add handshake timeout configuration to the libp2p transport stack to ensure
that connection handshakes do not hang indefinitely.
Add a test case verifying that dialing an unreachable peer triggers a timeout
or connection refused error within the configured timeout period, preventing hangs.
This improves network robustness by enforcing timely failure of unreachable peer dials.