### PR TITLE
Streamline logs and remove network difficulty

### DIFF
--- a/stratum/src/difficulty_adjuster.rs
+++ b/stratum/src/difficulty_adjuster.rs
@@ -75,18 +75,12 @@ pub struct DifficultyAdjuster {
     pub pool_minimum_difficulty: u64,
     /// Pool maximum difficulty
     pub pool_maximum_difficulty: Option<u64>,
-    /// Network difficulty
-    pub network_difficulty: u64,
 }
 
 #[cfg_attr(test, automock)]
 pub trait DifficultyAdjusterTrait {
     /// Create a new DifficultyAdjuster with the given minimum difficulty
-    fn new(
-        pool_minimum_difficulty: u64,
-        pool_maximum_difficulty: Option<u64>,
-        network_difficulty: u64,
-    ) -> Self;
+    fn new(pool_minimum_difficulty: u64, pool_maximum_difficulty: Option<u64>) -> Self;
 
     /// Records a share submission and updates metrics
     ///
@@ -117,9 +111,6 @@ pub trait DifficultyAdjusterTrait {
     /// Reset the difficulty adjuster with a new minimum difficulty
     fn reset(&mut self, pool_minimum_difficulty: u64);
 
-    /// Set the network difficulty
-    fn set_network_difficulty(&mut self, network_difficulty: u64);
-
     /// Convert a u128 value to u64, saturating at u64::MAX if the value exceeds it.
     #[inline]
     fn saturated_to_u64(&self, value: u128) -> u64 {
@@ -132,11 +123,7 @@ pub trait DifficultyAdjusterTrait {
 }
 
 impl DifficultyAdjusterTrait for DifficultyAdjuster {
-    fn new(
-        pool_minimum_difficulty: u64,
-        pool_maximum_difficulty: Option<u64>,
-        network_difficulty: u64,
-    ) -> Self {
+    fn new(pool_minimum_difficulty: u64, pool_maximum_difficulty: Option<u64>) -> Self {
         Self {
             share_submission_difficulty_counter: 0,
             current_difficulty: pool_minimum_difficulty,
@@ -151,7 +138,6 @@ impl DifficultyAdjusterTrait for DifficultyAdjuster {
             last_diff_change_job_id: None,
             pool_minimum_difficulty,
             pool_maximum_difficulty,
-            network_difficulty,
         }
     }
 
@@ -294,6 +280,12 @@ impl DifficultyAdjusterTrait for DifficultyAdjuster {
         calculated_diff: u64,
         suggested_difficulty: Option<u64>,
     ) -> u64 {
+        debug!(
+            "Applying difficulty constraints: calculated={}, pool_min={}, pool_max={}",
+            calculated_diff,
+            self.pool_minimum_difficulty,
+            self.pool_maximum_difficulty.unwrap_or(u64::MAX),
+        );
         // Maximum of pool minimum difficulty and calculated optimal
         let mut diff = calculated_diff.max(self.pool_minimum_difficulty);
 
@@ -306,9 +298,7 @@ impl DifficultyAdjusterTrait for DifficultyAdjuster {
         if self.pool_maximum_difficulty.is_some() {
             diff = diff.min(self.pool_maximum_difficulty.unwrap());
         }
-
-        // Minimum of diff and network difficulty
-        diff.min(self.network_difficulty)
+        diff
     }
 
     fn update_difficulty_shares_per_second_metric(
@@ -365,10 +355,6 @@ impl DifficultyAdjusterTrait for DifficultyAdjuster {
         self.difficulty_shares_per_second_7day_window = 0.0;
         self.last_diff_change_job_id = None;
     }
-
-    fn set_network_difficulty(&mut self, network_difficulty: u64) {
-        self.network_difficulty = network_difficulty;
-    }
 }
 
 #[cfg(test)]
@@ -379,8 +365,7 @@ mod tests {
     fn test_new_difficulty_adjuster() {
         let min_diff = 1000;
         let pool_max_diff = 100000;
-        let network_diff = 200000;
-        let adjuster = DifficultyAdjuster::new(min_diff, Some(pool_max_diff), network_diff);
+        let adjuster = DifficultyAdjuster::new(min_diff, Some(pool_max_diff));
 
         assert_eq!(adjuster.current_difficulty, min_diff);
         assert_eq!(adjuster.old_difficulty, min_diff);
@@ -398,7 +383,7 @@ mod tests {
     #[test]
     fn test_first_share_submission() {
         let min_diff = 1000;
-        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000), 200000);
+        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000));
 
         let (new_diff, is_first) = adjuster.record_share_submission(min_diff as u128, 1, None);
 
@@ -412,7 +397,7 @@ mod tests {
     #[test]
     fn test_difficulty_not_changed_before_minimum_shares() {
         let min_diff = 1000;
-        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000), 200000);
+        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000));
 
         // Submit first share to initialize
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None);
@@ -435,7 +420,7 @@ mod tests {
     #[test_log::test]
     fn test_difficulty_adjustment_after_minimum_time() {
         let min_diff = 1;
-        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000), 200000);
+        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000));
 
         // Submit first share to initialize
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None);
@@ -462,7 +447,7 @@ mod tests {
     #[test_log::test]
     fn test_difficulty_adjustment_after_enough_shares() {
         let min_diff = 1;
-        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000), 200000);
+        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000));
 
         // Submit first share to initialize
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None);
@@ -495,8 +480,7 @@ mod tests {
     fn test_difficulty_constraints() {
         let min_diff = 1000;
         let pool_max_diff = 100_000;
-        let network_diff = 500_000; // Higher than pool_max_diff to test constraints
-        let adjuster = DifficultyAdjuster::new(min_diff, Some(pool_max_diff), network_diff);
+        let adjuster = DifficultyAdjuster::new(min_diff, Some(pool_max_diff));
 
         // Test minimum constraint
         let calculated = 500; // Below pool minimum
@@ -508,14 +492,6 @@ mod tests {
         let constrained = adjuster.apply_difficulty_constraints(calculated, None);
         assert_eq!(constrained, pool_max_diff);
 
-        let network_diff = 50_000; // Lower than pool_max to test constraint
-        let adjuster = DifficultyAdjuster::new(min_diff, Some(pool_max_diff), network_diff);
-
-        // Test network constraint
-        let calculated = 75_000; // Above network but below pool max
-        let constrained = adjuster.apply_difficulty_constraints(calculated, None);
-        assert_eq!(constrained, network_diff);
-
         // Test cap with suggested difficulty
         let calculated = 500;
         let constrained = adjuster.apply_difficulty_constraints(calculated, Some(2000));
@@ -525,7 +501,7 @@ mod tests {
     #[test]
     fn test_adjust_dsps_bias_and_drr() {
         let min_diff = 1000;
-        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100_000), 200_000);
+        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100_000));
 
         // Submit first share to initialize
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None);
@@ -551,7 +527,7 @@ mod tests {
     #[test]
     fn test_no_change_within_drr_threshold() {
         let min_diff = 1000;
-        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000), 200000);
+        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000));
 
         // Submit first share to initialize
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None);
@@ -574,7 +550,7 @@ mod tests {
     #[test_log::test]
     fn test_time_bias_effect() {
         let min_diff = 1000;
-        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000), 200000);
+        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000));
 
         // Submit first share to initialize
         let _ = adjuster.record_share_submission(min_diff as u128, 1, None);
@@ -604,7 +580,7 @@ mod tests {
     #[test]
     fn test_reset_adjuster() {
         let min_diff = 1000;
-        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000), 200000);
+        let mut adjuster = DifficultyAdjuster::new(min_diff, Some(100000));
 
         // Make some changes to the adjuster state
         adjuster.record_share_submission(min_diff as u128, 1, None);

--- a/stratum/src/difficulty_adjuster.rs
+++ b/stratum/src/difficulty_adjuster.rs
@@ -284,7 +284,10 @@ impl DifficultyAdjusterTrait for DifficultyAdjuster {
             "Applying difficulty constraints: calculated={}, pool_min={}, pool_max={}",
             calculated_diff,
             self.pool_minimum_difficulty,
-            self.pool_maximum_difficulty.unwrap_or(u64::MAX),
+            match self.pool_maximum_difficulty {
+                Some(max) => max.to_string(),
+                None => "None".to_string(),
+            },
         );
         // Maximum of pool minimum difficulty and calculated optimal
         let mut diff = calculated_diff.max(self.pool_minimum_difficulty);

--- a/stratum/src/difficulty_adjuster.rs
+++ b/stratum/src/difficulty_adjuster.rs
@@ -220,7 +220,7 @@ impl DifficultyAdjusterTrait for DifficultyAdjuster {
         if should_adjust {
             let new_diff = self.calculate_new_difficulty(suggested_difficulty);
 
-            info!(
+            debug!(
                 "Calculated new difficulty: {}, current difficulty: {}",
                 new_diff, self.current_difficulty
             );
@@ -280,7 +280,7 @@ impl DifficultyAdjusterTrait for DifficultyAdjuster {
         // Apply constraints to the calculated difficulty
         let constrained_diff = self.apply_difficulty_constraints(saturated, suggested_difficulty);
 
-        info!(
+        debug!(
             "Difficulty adjustment: dsps5={}, bias={}, adjusted_dsps={}, drr={}, optimal={}, constrained={}",
             self.difficulty_shares_per_second_5min_window, bias, difficulty_shares_per_second, difficulty_rate_ratio, optimal_diff, constrained_diff
         );

--- a/stratum/src/message_handlers/authorize.rs
+++ b/stratum/src/message_handlers/authorize.rs
@@ -69,7 +69,7 @@ mod tests {
     #[tokio::test]
     async fn test_handle_authorize_first_time() {
         // Setup
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 1, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
         let request =
             SimpleRequest::new_authorize(12345, "worker1".to_string(), Some("x".to_string()));
         let (notify_tx, mut notify_rx) = tokio::sync::mpsc::channel(1);
@@ -123,7 +123,7 @@ mod tests {
     #[tokio::test]
     async fn test_handle_authorize_already_authorized() {
         // Setup
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 1, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
         session.username = Some("someusername".to_string());
         let request = SimpleRequest::new_authorize(
             12345,

--- a/stratum/src/message_handlers/configure.rs
+++ b/stratum/src/message_handlers/configure.rs
@@ -25,7 +25,7 @@ pub async fn handle_configure<'a, D: DifficultyAdjusterTrait>(
     request: Request<'a>,
     session: &Session<D>,
 ) -> Result<Vec<Message<'a>>, Error> {
-    info!("Handling mining.configure message");
+    debug!("Handling mining.configure message");
     match request {
         Request::MiningConfigureRequest(configure) => {
             debug!("Received mining.configure request: {:?}", configure);

--- a/stratum/src/message_handlers/configure.rs
+++ b/stratum/src/message_handlers/configure.rs
@@ -18,7 +18,7 @@ use crate::difficulty_adjuster::DifficultyAdjusterTrait;
 use crate::error::Error;
 use crate::messages::{Message, MiningConfigure, Request, Response};
 use crate::session::Session;
-use tracing::{debug, info};
+use tracing::debug;
 
 /// Handle the "mining.configure" message
 pub async fn handle_configure<'a, D: DifficultyAdjusterTrait>(
@@ -72,7 +72,7 @@ mod mining_configure_response_tests {
             None,
         );
 
-        let session = Session::<DifficultyAdjuster>::new(1, Some(1000), 100000, 0x1fffe000);
+        let session = Session::<DifficultyAdjuster>::new(1, Some(1000), 0x1fffe000);
 
         let result = handle_configure(message, &session).await;
         assert!(result.is_ok());

--- a/stratum/src/message_handlers/submit.rs
+++ b/stratum/src/message_handlers/submit.rs
@@ -142,7 +142,7 @@ mod handle_submit_tests {
 
     #[test_log::test(tokio::test)]
     async fn test_handle_submit_meets_difficulty_should_submit() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 2, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -218,7 +218,7 @@ mod handle_submit_tests {
 
     #[tokio::test]
     async fn test_handle_submit_a_meets_difficulty_should_submit() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 2, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -295,7 +295,7 @@ mod handle_submit_tests {
 
     #[test_log::test(tokio::test)]
     async fn test_handle_submit_with_version_rolling_meets_difficulty_should_submit() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 2, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -373,14 +373,14 @@ mod handle_submit_tests {
     #[tokio::test]
     async fn test_handle_submit_triggers_difficulty_adjustment() {
         let ctx = MockDifficultyAdjusterTrait::new_context();
-        ctx.expect().returning(|_, _, _| {
+        ctx.expect().returning(|_, _| {
             let mut mock = MockDifficultyAdjusterTrait::default();
             mock.expect_record_share_submission()
                 .returning(|_difficulty, _job_id, _suggested_difficulty| (Some(12345), false));
             mock
         });
 
-        let mut session = Session::<MockDifficultyAdjusterTrait>::new(1, None, 2, 0x1fffe000);
+        let mut session = Session::<MockDifficultyAdjusterTrait>::new(1, None, 0x1fffe000);
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -454,7 +454,7 @@ mod handle_submit_tests {
 
     #[tokio::test]
     async fn test_handle_submit_with_unknown_job_id_returns_false() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 2, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
         let tracker_handle = start_tracker_actor();
 
         let (_mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;

--- a/stratum/src/message_handlers/subscribe.rs
+++ b/stratum/src/message_handlers/subscribe.rs
@@ -64,7 +64,7 @@ mod tests {
     async fn test_handle_subscribe_success() {
         // Setup
         let message = SimpleRequest::new_subscribe(1, "UA".to_string(), "v1.0".to_string(), None);
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 2, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
         session.subscribed = false;
 
         // Execute
@@ -130,7 +130,7 @@ mod tests {
     async fn test_handle_subscribe_already_subscribed() {
         // Setup
         let message = SimpleRequest::new_subscribe(1, "UA".to_string(), "v1.0".to_string(), None);
-        let mut session = Session::<DifficultyAdjuster>::new(2, None, 2, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(2, None, 0x1fffe000);
         session.subscribed = true;
 
         // Execute

--- a/stratum/src/message_handlers/suggest_difficulty.rs
+++ b/stratum/src/message_handlers/suggest_difficulty.rs
@@ -55,7 +55,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_suggest_difficulty_valid_param() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 2000, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
         let request = SuggestDifficulty {
             id: Some(Id::Number(1)),
             method: "mining.suggest_difficulty".into(),
@@ -77,7 +77,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_suggest_difficulty_should_respect_pool_max_difficulty() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 1, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, Some(100), 0x1fffe000);
         let request = SuggestDifficulty {
             id: Some(Id::Number(1)),
             method: "mining.suggest_difficulty".into(),
@@ -90,10 +90,10 @@ mod tests {
         let messages = result.unwrap();
         assert_eq!(messages.len(), 1);
         if let Message::SetDifficulty(notification) = &messages[0] {
-            assert_eq!(notification.params[0], 1);
+            assert_eq!(notification.params[0], 100);
         } else {
             panic!("Expected SetDifficulty message");
         }
-        assert_eq!(session.suggested_difficulty, Some(1));
+        assert_eq!(session.suggested_difficulty, Some(100));
     }
 }

--- a/stratum/src/server.rs
+++ b/stratum/src/server.rs
@@ -167,7 +167,6 @@ where
     let session = &mut Session::<DifficultyAdjuster>::new(
         ctx.minimum_difficulty,
         ctx.maximum_difficulty,
-        ctx.maximum_difficulty.unwrap_or(ctx.minimum_difficulty),
         version_mask,
     );
 

--- a/stratum/src/server.rs
+++ b/stratum/src/server.rs
@@ -196,7 +196,7 @@ where
             }
             // Read a line from the stream
             line = framed.next() => {
-                debug!("Read line {:?} from {}...", line, addr);
+                info!("Rx {} {:?}", addr, line);
                 match line {
                     Some(Ok(line)) => {
                         if line.is_empty() {
@@ -254,7 +254,7 @@ where
                         }
                     };
 
-                    info!("Sending to {}: {:?}", addr, response_json);
+                    info!("Tx {} {:?}", addr, response_json);
                     if let Err(e) = writer
                         .write_all(format!("{}\n", response_json).as_bytes())
                         .await

--- a/stratum/src/session.rs
+++ b/stratum/src/session.rs
@@ -51,7 +51,6 @@ impl<D: DifficultyAdjusterTrait> Session<D> {
     pub fn new(
         minimum_difficulty: u64,
         maximum_difficulty: Option<u64>,
-        network_difficulty: u64,
         version_mask: i32,
     ) -> Self {
         let id = Session::<D>::generate_id();
@@ -63,7 +62,7 @@ impl<D: DifficultyAdjusterTrait> Session<D> {
             subscribed: false,
             username: None,
             password: None,
-            difficulty_adjuster: D::new(minimum_difficulty, maximum_difficulty, network_difficulty),
+            difficulty_adjuster: D::new(minimum_difficulty, maximum_difficulty),
             version_mask,
             suggested_difficulty: None,
         }
@@ -84,8 +83,7 @@ mod tests {
     #[test]
     fn test_new_session() {
         let min_difficulty = 1000;
-        let session =
-            Session::<DifficultyAdjuster>::new(min_difficulty, Some(2000), 1500, 0x1fffe000);
+        let session = Session::<DifficultyAdjuster>::new(min_difficulty, Some(2000), 0x1fffe000);
 
         assert_eq!(
             session.difficulty_adjuster.pool_minimum_difficulty,
@@ -133,8 +131,7 @@ mod tests {
     #[test]
     fn test_get_current_difficulty() {
         let min_difficulty = 2000;
-        let session =
-            Session::<DifficultyAdjuster>::new(min_difficulty, Some(3000), 2500, 0x1fffe000);
+        let session = Session::<DifficultyAdjuster>::new(min_difficulty, Some(3000), 0x1fffe000);
 
         assert_eq!(
             session.difficulty_adjuster.current_difficulty,

--- a/stratum/src/work/difficulty/validate.rs
+++ b/stratum/src/work/difficulty/validate.rs
@@ -21,7 +21,7 @@ use crate::work::tracker::JobDetails;
 use bitcoin::blockdata::block::{Block, Header};
 use bitcoin::consensus::Decodable;
 use std::str::FromStr;
-use tracing::{debug, info};
+use tracing::debug;
 
 /// parse all transactions from block template with data and txid
 fn decode_txids(blocktemplate: &BlockTemplate) -> Result<Vec<bitcoin::Txid>, Error> {
@@ -68,7 +68,7 @@ fn apply_version_mask(
     params: &[String],
 ) -> Result<i32, Error> {
     if params.len() > 5 {
-        info!("Applying version mask from params: {}", params[5]);
+        debug!("Applying version mask from params: {}", params[5]);
         let bits = i32::from_be_bytes(
             hex::decode(&params[5])
                 .map_err(|_| Error::InvalidParams("Failed to decode hex".into()))?
@@ -116,7 +116,7 @@ pub fn validate_submission_difficulty(
         .map(|h| h.into())
         .unwrap();
 
-    info!("Merkle root: {}", merkle_root);
+    debug!("Merkle root: {}", merkle_root);
 
     let n_time = u32::from_str_radix(&submission.params[3], 16)
         .map_err(|_| Error::InvalidParams("Bad nTime".into()))?;
@@ -133,13 +133,12 @@ pub fn validate_submission_difficulty(
         nonce: u32::from_str_radix(&submission.params[4], 16).unwrap(),
     };
 
-    info!("Header hash : {}", header.block_hash().to_string());
-    // info!("Target      : {}", hex::encode(target));
+    debug!("Header hash : {}", header.block_hash().to_string());
 
     match header.validate_pow(target) {
-        Ok(_) => info!("Header meets the target"),
+        Ok(_) => debug!("Header meets the target"),
         Err(e) => {
-            info!("Header does not meet the target: {}", e);
+            debug!("Header does not meet the target: {}", e);
             return Err(Error::InsufficientWork);
         }
     }

--- a/stratum/src/work/notify.rs
+++ b/stratum/src/work/notify.rs
@@ -346,7 +346,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_notify_from_ckpool_sample() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 1, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
         let _tracker_handle = start_tracker_actor();
 
         let (mock_server, _bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;


### PR DESCRIPTION
Move verbose logs from info to debug as we get ready to test.

It will be slow to update all sessions with network difficulty, and we are also not sure how we'll impose network difficulty constraints, if at all. Remove it for now and we can bring it back once we are clear how to track and use it.