### PR TITLE
fixed parsing

### DIFF
--- a/tools/log_dashboard/templates/index.html
+++ b/tools/log_dashboard/templates/index.html
@@ -78,8 +78,8 @@ P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
                 <th scope="col">Status</th>
                 <th scope="col">User Agent</th>
                 <th scope="col">Submits</th>
-                <th scope="col">Last Session Log</th>
                 <th scope="col">Usernames</th>
+                <th scope="col">Last Session Log</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Problem
Older connect/disconnect lines were skipped due to the last_processed timestamp filter, breaking ipport → useragent mapping for later submits.

Fix
Process connect/disconnect lines regardless of timestamp to maintain session state. Keep submit/result lines gated by last_processed.

Changes
Moved last_processed check after handling connect/disconnect.

Logic for counting submits/results remains unchanged.