### PR TITLE
Create new connection for each gbt

### DIFF
--- a/p2poolv2_bin/src/main.rs
+++ b/p2poolv2_bin/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<(), String> {
 
     tokio::spawn(async move {
         if let Err(e) = start_gbt(
-            &bitcoinrpc_config_cloned,
+            bitcoinrpc_config_cloned,
             notify_tx_for_gbt,
             SOCKET_PATH,
             GBT_POLL_INTERVAL,


### PR DESCRIPTION
bitcoind's RPC has very low timeout limits and it doesn't send a connection termination when a connection is killed.

For the sake of making things reliable as opposed to optimised, which can occassionally break, we are taking the approach of creating a new http connection for each getblocktemplate and blocksubmit request.