### PR TITLE
Use optional strings in simple requests

### DIFF
--- a/stratum/src/message_handlers/authorize.rs
+++ b/stratum/src/message_handlers/authorize.rs
@@ -46,8 +46,8 @@ pub async fn handle_authorize<'a, D: DifficultyAdjusterTrait>(
             "Already authorized".to_string(),
         ));
     }
-    session.username = Some(message.params[0].clone());
-    session.password = Some(message.params[1].clone());
+    session.username = message.params[0].clone();
+    session.password = message.params[1].clone();
     let _ = notify_tx
         .send(NotifyCmd::SendToClient {
             client_address: addr,

--- a/stratum/src/message_handlers/submit.rs
+++ b/stratum/src/message_handlers/submit.rs
@@ -52,8 +52,10 @@ pub async fn handle_submit<'a, D: DifficultyAdjusterTrait>(
         return Err(Error::InvalidParams("Missing parameters".into()));
     }
 
-    let job_id = u64::from_str_radix(&message.params[1], 16)
-        .map_err(|_| Error::InvalidParams("Invalid job_id".into()))?;
+    let id = message.params[1].as_ref().unwrap();
+
+    let job_id =
+        u64::from_str_radix(id, 16).map_err(|_| Error::InvalidParams("Invalid job_id".into()))?;
 
     let job = match tracker_handle.get_job(JobId(job_id)).await {
         Ok(Some(job)) => job,
@@ -469,7 +471,7 @@ mod handle_submit_tests {
 
         // Overwrite job_id param to an unknown value (e.g., "deadbeef")
         if submit.params.len() > 1 {
-            submit.params.to_mut()[1] = "deadbeef".to_string();
+            submit.params.to_mut()[1] = Some("deadbeef".to_string());
         }
 
         // Set enonce1 from authorize_response


### PR DESCRIPTION
Some clients send null fields in subscribe. To handle that
the params in requests needs to a vector of optional
strings.