### PR TITLE
Streamline storing current diff in session

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,8 +26,8 @@ port = 8881
 [stratum]
 hostname = "0.0.0.0"
 port = 3333
-start_difficulty = 1000
-minimum_difficulty = 1000
+start_difficulty = 10000
+minimum_difficulty = 100
 solo_address = "tb1qyazxde6558qj6z3d9np5e6msmrspwpf6k0qggk"
 zmqpubhashblock = "tcp://127.0.0.1:28332"
 # The network can be "main", "testnet4" or "signet"

--- a/docs/difficulty_adjustment/ckpool.md
+++ b/docs/difficulty_adjustment/ckpool.md
@@ -79,8 +79,8 @@ The system targets a specific difficulty rate ratio (DRR):
 
 - Optimal ratio is approximately 0.3 (shares every ~3.33 seconds)
 - System uses hysteresis: only adjusts if DRR < 0.15 or DRR > 0.4
-- Target difficulty is calculated as: $optimal\_diff = dsps \times 3.33$ (for standard clients)
-- For clients with minimum difficulty specified: $optimal\_diff = dsps \times 2.4$. We will ignore this in our first implementation.
+- Target difficulty is calculated as: $optimal\_{diff} = dsps \times 3.33$ (for standard clients)
+- For clients with minimum difficulty specified: $optimal\_{diff} = dsps \times 2.4$. We will ignore this in our first implementation.
 
 ## Difficulty Constraint Logic
 

--- a/p2poolv2_lib/src/command/mod.rs
+++ b/p2poolv2_lib/src/command/mod.rs
@@ -15,8 +15,6 @@
 // P2Poolv2. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::node::messages::Message;
-use crate::shares::ShareBlock;
-use crate::shares::miner_message::MinerWorkbase;
 use std::error::Error;
 use tokio::sync::oneshot;
 

--- a/stratum/src/message_handlers/authorize.rs
+++ b/stratum/src/message_handlers/authorize.rs
@@ -48,6 +48,9 @@ pub async fn handle_authorize<'a, D: DifficultyAdjusterTrait>(
     }
     session.username = message.params[0].clone();
     session.password = message.params[1].clone();
+    session
+        .difficulty_adjuster
+        .set_current_difficulty(start_difficulty);
     let _ = notify_tx
         .send(NotifyCmd::SendToClient {
             client_address: addr,
@@ -69,7 +72,7 @@ mod tests {
     #[tokio::test]
     async fn test_handle_authorize_first_time() {
         // Setup
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
         let request =
             SimpleRequest::new_authorize(12345, "worker1".to_string(), Some("x".to_string()));
         let (notify_tx, mut notify_rx) = tokio::sync::mpsc::channel(1);
@@ -123,7 +126,7 @@ mod tests {
     #[tokio::test]
     async fn test_handle_authorize_already_authorized() {
         // Setup
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
         session.username = Some("someusername".to_string());
         let request = SimpleRequest::new_authorize(
             12345,

--- a/stratum/src/message_handlers/authorize.rs
+++ b/stratum/src/message_handlers/authorize.rs
@@ -37,7 +37,7 @@ pub async fn handle_authorize<'a, D: DifficultyAdjusterTrait>(
     session: &mut Session<D>,
     addr: std::net::SocketAddr,
     notify_tx: tokio::sync::mpsc::Sender<NotifyCmd>,
-    pool_min_difficulty: u64,
+    start_difficulty: u64,
 ) -> Result<Vec<Message<'a>>, Error> {
     debug!("Handling mining.authorize message");
     if session.username.is_some() {
@@ -55,7 +55,7 @@ pub async fn handle_authorize<'a, D: DifficultyAdjusterTrait>(
         .await;
     Ok(vec![
         Message::Response(Response::new_ok(message.id, serde_json::json!(true))),
-        Message::SetDifficulty(SetDifficultyNotification::new(pool_min_difficulty)),
+        Message::SetDifficulty(SetDifficultyNotification::new(start_difficulty)),
     ])
 }
 

--- a/stratum/src/message_handlers/configure.rs
+++ b/stratum/src/message_handlers/configure.rs
@@ -72,7 +72,7 @@ mod mining_configure_response_tests {
             None,
         );
 
-        let session = Session::<DifficultyAdjuster>::new(1, Some(1000), 0x1fffe000);
+        let session = Session::<DifficultyAdjuster>::new(1, 1, Some(1000), 0x1fffe000);
 
         let result = handle_configure(message, &session).await;
         assert!(result.is_ok());

--- a/stratum/src/message_handlers/mod.rs
+++ b/stratum/src/message_handlers/mod.rs
@@ -67,16 +67,9 @@ async fn handle_simple_request<'a, D: DifficultyAdjusterTrait>(
 ) -> Result<Vec<Message<'a>>, Error> {
     debug!("Handling simple request: {}", message.method);
     match message.method.as_ref() {
-        "mining.subscribe" => handle_subscribe(message, session, ctx.minimum_difficulty).await,
+        "mining.subscribe" => handle_subscribe(message, session, ctx.start_difficulty).await,
         "mining.authorize" => {
-            handle_authorize(
-                message,
-                session,
-                addr,
-                ctx.notify_tx,
-                ctx.minimum_difficulty,
-            )
-            .await
+            handle_authorize(message, session, addr, ctx.notify_tx, ctx.start_difficulty).await
         }
         "mining.submit" => {
             handle_submit(

--- a/stratum/src/message_handlers/mod.rs
+++ b/stratum/src/message_handlers/mod.rs
@@ -72,14 +72,7 @@ async fn handle_simple_request<'a, D: DifficultyAdjusterTrait>(
             handle_authorize(message, session, addr, ctx.notify_tx, ctx.start_difficulty).await
         }
         "mining.submit" => {
-            handle_submit(
-                message,
-                session,
-                ctx.tracker_handle,
-                ctx.bitcoinrpc_config,
-                ctx.network,
-            )
-            .await
+            handle_submit(message, session, ctx.tracker_handle, ctx.bitcoinrpc_config).await
         }
         method => Err(Error::InvalidMethod(method.to_string())),
     }

--- a/stratum/src/message_handlers/submit.rs
+++ b/stratum/src/message_handlers/submit.rs
@@ -167,7 +167,7 @@ mod handle_submit_tests {
 
     #[test_log::test(tokio::test)]
     async fn test_handle_submit_meets_difficulty_should_submit() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -237,7 +237,7 @@ mod handle_submit_tests {
 
     #[tokio::test]
     async fn test_handle_submit_a_meets_difficulty_should_submit() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -308,7 +308,7 @@ mod handle_submit_tests {
 
     #[test_log::test(tokio::test)]
     async fn test_handle_submit_with_version_rolling_meets_difficulty_should_submit() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -380,14 +380,14 @@ mod handle_submit_tests {
     #[tokio::test]
     async fn test_handle_submit_triggers_difficulty_adjustment() {
         let ctx = MockDifficultyAdjusterTrait::new_context();
-        ctx.expect().returning(|_, _| {
+        ctx.expect().returning(|_, _, _| {
             let mut mock = MockDifficultyAdjusterTrait::default();
             mock.expect_record_share_submission()
                 .returning(|_difficulty, _job_id, _suggested_difficulty| (Some(12345), false));
             mock
         });
 
-        let mut session = Session::<MockDifficultyAdjusterTrait>::new(1, None, 0x1fffe000);
+        let mut session = Session::<MockDifficultyAdjusterTrait>::new(1, 1, None, 0x1fffe000);
         let tracker_handle = start_tracker_actor();
 
         let (mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;
@@ -455,7 +455,7 @@ mod handle_submit_tests {
 
     #[tokio::test]
     async fn test_handle_submit_with_unknown_job_id_returns_false() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
         let tracker_handle = start_tracker_actor();
 
         let (_mock_server, bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;

--- a/stratum/src/message_handlers/subscribe.rs
+++ b/stratum/src/message_handlers/subscribe.rs
@@ -29,7 +29,7 @@ use tracing::debug;
 pub async fn handle_subscribe<'a, D: DifficultyAdjusterTrait>(
     message: SimpleRequest<'a>,
     session: &mut Session<D>,
-    pool_min_difficulty: u64,
+    start_difficulty: u64,
 ) -> Result<Vec<Message<'a>>, Error> {
     debug!("Handling mining.subscribe message");
     if session.subscribed {
@@ -49,7 +49,7 @@ pub async fn handle_subscribe<'a, D: DifficultyAdjusterTrait>(
                 EXTRANONCE2_SIZE,
             ]),
         )),
-        Message::SetDifficulty(SetDifficultyNotification::new(pool_min_difficulty)),
+        Message::SetDifficulty(SetDifficultyNotification::new(start_difficulty)),
     ])
 }
 

--- a/stratum/src/message_handlers/subscribe.rs
+++ b/stratum/src/message_handlers/subscribe.rs
@@ -37,6 +37,9 @@ pub async fn handle_subscribe<'a, D: DifficultyAdjusterTrait>(
         return Err(Error::SubscriptionFailure("Already subscribed".to_string()));
     }
     session.subscribed = true;
+    session
+        .difficulty_adjuster
+        .set_current_difficulty(start_difficulty);
     Ok(vec![
         Message::Response(Response::new_ok(
             message.id,
@@ -64,7 +67,7 @@ mod tests {
     async fn test_handle_subscribe_success() {
         // Setup
         let message = SimpleRequest::new_subscribe(1, "UA".to_string(), "v1.0".to_string(), None);
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
         session.subscribed = false;
 
         // Execute
@@ -130,7 +133,7 @@ mod tests {
     async fn test_handle_subscribe_already_subscribed() {
         // Setup
         let message = SimpleRequest::new_subscribe(1, "UA".to_string(), "v1.0".to_string(), None);
-        let mut session = Session::<DifficultyAdjuster>::new(2, None, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(2, 2, None, 0x1fffe000);
         session.subscribed = true;
 
         // Execute

--- a/stratum/src/message_handlers/suggest_difficulty.rs
+++ b/stratum/src/message_handlers/suggest_difficulty.rs
@@ -33,7 +33,7 @@ pub async fn handle_suggest_difficulty<'a, D: DifficultyAdjusterTrait>(
         Some(param) => {
             let difficulty = session
                 .difficulty_adjuster
-                .apply_difficulty_constraints(*param, None);
+                .apply_difficulty_constraints(*param, Some(*param));
             session.suggested_difficulty = Some(difficulty);
             debug!("Suggested difficulty set to {}", difficulty);
             Ok(vec![Message::SetDifficulty(

--- a/stratum/src/message_handlers/suggest_difficulty.rs
+++ b/stratum/src/message_handlers/suggest_difficulty.rs
@@ -35,6 +35,9 @@ pub async fn handle_suggest_difficulty<'a, D: DifficultyAdjusterTrait>(
                 .difficulty_adjuster
                 .apply_difficulty_constraints(*param, Some(*param));
             session.suggested_difficulty = Some(difficulty);
+            session
+                .difficulty_adjuster
+                .set_current_difficulty(difficulty);
             debug!("Suggested difficulty set to {}", difficulty);
             Ok(vec![Message::SetDifficulty(
                 SetDifficultyNotification::new(difficulty),
@@ -55,7 +58,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_suggest_difficulty_valid_param() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
         let request = SuggestDifficulty {
             id: Some(Id::Number(1)),
             method: "mining.suggest_difficulty".into(),
@@ -77,7 +80,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_suggest_difficulty_should_respect_pool_max_difficulty() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, Some(100), 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, Some(100), 0x1fffe000);
         let request = SuggestDifficulty {
             id: Some(Id::Number(1)),
             method: "mining.suggest_difficulty".into(),

--- a/stratum/src/server.rs
+++ b/stratum/src/server.rs
@@ -109,6 +109,7 @@ impl StratumServer {
                                 notify_tx: notify_tx.clone(),
                                 tracker_handle: tracker_handle.clone(),
                                 bitcoinrpc_config: bitcoinrpc_config.clone(),
+                                start_difficulty: self.config.start_difficulty,
                                 minimum_difficulty: self.config.minimum_difficulty,
                                 maximum_difficulty: self.config.maximum_difficulty,
                                 network: self.config.network,
@@ -138,6 +139,7 @@ pub(crate) struct StratumContext {
     pub notify_tx: mpsc::Sender<NotifyCmd>,
     pub tracker_handle: TrackerHandle,
     pub bitcoinrpc_config: BitcoinRpcConfig,
+    pub start_difficulty: u64,
     pub minimum_difficulty: u64,
     pub maximum_difficulty: Option<u64>,
     pub network: bitcoin::network::Network,
@@ -360,6 +362,7 @@ mod stratum_server_tests {
             notify_tx,
             tracker_handle,
             bitcoinrpc_config,
+            start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
             network: bitcoin::network::Network::Regtest,
@@ -435,8 +438,8 @@ mod stratum_server_tests {
         );
         assert_eq!(
             set_difficulty_json.get("params").unwrap(),
-            &serde_json::json!([1]),
-            "Set difficulty response should have params [1]"
+            &serde_json::json!([10000]),
+            "Set difficulty response should have params [10000]"
         );
 
         assert!(response.ends_with("\n"),);
@@ -461,6 +464,7 @@ mod stratum_server_tests {
             notify_tx,
             tracker_handle,
             bitcoinrpc_config,
+            start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
             network: bitcoin::network::Network::Regtest,
@@ -516,6 +520,7 @@ mod stratum_server_tests {
             notify_tx,
             tracker_handle,
             bitcoinrpc_config,
+            start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
             network: bitcoin::network::Network::Regtest,
@@ -576,6 +581,7 @@ mod stratum_server_tests {
             notify_tx,
             tracker_handle,
             bitcoinrpc_config,
+            start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
             network: bitcoin::network::Network::Regtest,
@@ -656,6 +662,7 @@ mod stratum_server_tests {
             notify_tx,
             tracker_handle,
             bitcoinrpc_config,
+            start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
             network: bitcoin::network::Network::Regtest,
@@ -755,6 +762,7 @@ mod stratum_server_tests {
             notify_tx,
             tracker_handle,
             bitcoinrpc_config,
+            start_difficulty: 10000,
             minimum_difficulty: 1,
             maximum_difficulty: Some(2),
             network: bitcoin::network::Network::Regtest,

--- a/stratum/src/server.rs
+++ b/stratum/src/server.rs
@@ -167,6 +167,7 @@ where
 
     let mut framed = FramedRead::new(reader, LinesCodec::new_with_max_length(MAX_LINE_LENGTH));
     let session = &mut Session::<DifficultyAdjuster>::new(
+        ctx.start_difficulty,
         ctx.minimum_difficulty,
         ctx.maximum_difficulty,
         version_mask,

--- a/stratum/src/session.rs
+++ b/stratum/src/session.rs
@@ -49,6 +49,7 @@ pub struct Session<D: DifficultyAdjusterTrait> {
 impl<D: DifficultyAdjusterTrait> Session<D> {
     /// Creates a new session with the given minimum difficulty.
     pub fn new(
+        start_difficulty: u64,
         minimum_difficulty: u64,
         maximum_difficulty: Option<u64>,
         version_mask: i32,
@@ -62,7 +63,7 @@ impl<D: DifficultyAdjusterTrait> Session<D> {
             subscribed: false,
             username: None,
             password: None,
-            difficulty_adjuster: D::new(minimum_difficulty, maximum_difficulty),
+            difficulty_adjuster: D::new(start_difficulty, minimum_difficulty, maximum_difficulty),
             version_mask,
             suggested_difficulty: None,
         }
@@ -83,7 +84,13 @@ mod tests {
     #[test]
     fn test_new_session() {
         let min_difficulty = 1000;
-        let session = Session::<DifficultyAdjuster>::new(min_difficulty, Some(2000), 0x1fffe000);
+        let start_difficulty = 100;
+        let session = Session::<DifficultyAdjuster>::new(
+            start_difficulty,
+            min_difficulty,
+            Some(2000),
+            0x1fffe000,
+        );
 
         assert_eq!(
             session.difficulty_adjuster.pool_minimum_difficulty,
@@ -91,7 +98,7 @@ mod tests {
         );
         assert_eq!(
             session.difficulty_adjuster.current_difficulty,
-            min_difficulty
+            start_difficulty
         );
         assert_ne!(session.id, "");
 
@@ -130,12 +137,8 @@ mod tests {
 
     #[test]
     fn test_get_current_difficulty() {
-        let min_difficulty = 2000;
-        let session = Session::<DifficultyAdjuster>::new(min_difficulty, Some(3000), 0x1fffe000);
+        let session = Session::<DifficultyAdjuster>::new(100, 2000, Some(3000), 0x1fffe000);
 
-        assert_eq!(
-            session.difficulty_adjuster.current_difficulty,
-            min_difficulty
-        );
+        assert_eq!(session.difficulty_adjuster.current_difficulty, 100);
     }
 }

--- a/stratum/src/work/gbt.rs
+++ b/stratum/src/work/gbt.rs
@@ -469,6 +469,13 @@ mod gbt_server_tests {
             "rules": ["segwit", "signet"],
         }]);
         mock_method(&mock_server, "getblocktemplate", params, template).await;
+        mock_method(
+            &mock_server,
+            "getdifficulty",
+            serde_json::json!([]),
+            "1".into(),
+        )
+        .await;
 
         let (_zmq_trigger_tx, zmq_trigger_rx) = mpsc::channel(1);
 
@@ -524,6 +531,13 @@ mod gbt_server_tests {
             "rules": ["segwit", "signet"],
         }]);
         mock_method(&mock_server, "getblocktemplate", params, template).await;
+        mock_method(
+            &mock_server,
+            "getdifficulty",
+            serde_json::json!([]),
+            "1".into(),
+        )
+        .await;
 
         let (_zmq_trigger_tx, zmq_trigger_rx) = mpsc::channel(1);
 
@@ -576,6 +590,13 @@ mod gbt_server_tests {
             "rules": ["segwit", "signet"],
         }]);
         mock_method(&mock_server, "getblocktemplate", params, template).await;
+        mock_method(
+            &mock_server,
+            "getdifficulty",
+            serde_json::json!([]),
+            "1".into(),
+        )
+        .await;
 
         let (zmq_trigger_tx, zmq_trigger_rx) = mpsc::channel(1);
 

--- a/stratum/src/work/gbt.rs
+++ b/stratum/src/work/gbt.rs
@@ -135,6 +135,19 @@ async fn get_block_template(
     }
 }
 
+/// Print the current network difficulty
+/// Called from start_gbt when it is first invoked
+async fn print_start_network_diff(bitcoin_config: &BitcoinRpcConfig) {
+    let bitcoind = BitcoindRpcClient::new(
+        &bitcoin_config.url,
+        &bitcoin_config.username,
+        &bitcoin_config.password,
+    )
+    .unwrap();
+    let difficulty = bitcoind.get_difficulty().await.unwrap();
+    info!("Bitcoin network difficulty: {}", difficulty);
+}
+
 /// Start a task to fetch block templates from bitcoind
 ///
 /// Listen to blocknotify signal from bitcoind.
@@ -147,6 +160,8 @@ pub async fn start_gbt(
     network: bitcoin::Network,
     mut zmq_trigger_rx: tokio::sync::mpsc::Receiver<()>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    print_start_network_diff(&bitcoin_config).await;
+
     let template = match get_block_template(&bitcoin_config, network).await {
         Ok(template) => template,
         Err(e) => {

--- a/stratum/src/work/notify.rs
+++ b/stratum/src/work/notify.rs
@@ -346,7 +346,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_notify_from_ckpool_sample() {
-        let mut session = Session::<DifficultyAdjuster>::new(1, None, 0x1fffe000);
+        let mut session = Session::<DifficultyAdjuster>::new(1, 1, None, 0x1fffe000);
         let _tracker_handle = start_tracker_actor();
 
         let (mock_server, _bitcoinrpc_config) = setup_mock_bitcoin_rpc().await;


### PR DESCRIPTION
When we send set_difficulty we need to update the difficulty adjuster's current difficulty to the new value. This is for times when we send set_diff in response to subscribe or suggest_difficulty